### PR TITLE
v1.5.3.230203

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   skip: True  # [py<38]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pandas-stubs" %}
-{% set version = "1.5.0.221003" %}
+{% set version = "1.5.3.230203" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 853ccd7c530db01eeee8293746fa00841f3342c90794eeefa504a093c35e6af9
+  sha256: 7a4eedb210c77e0911fe32a4178673ba68ef569c034117ea19ada79451db4af9
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps
-  skip: True  # [py<38]
+  # s390x is missing types-pytz>=2022.1.1
+  skip: True  # [py<38 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7a4eedb210c77e0911fe32a4178673ba68ef569c034117ea19ada79451db4af9
+  # As of 2/13/2023 archive was unavailable on PyPi
+  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/pandas-dev/pandas-stubs/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 16dbefc3c2d8fb2eed4970bcb74a8746e7520e34477a7b9b69afef00ec80ae83
 
 build:
   number: 0


### PR DESCRIPTION
# pandas-stubs 1.5.3.230203

upstream: https://github.com/pandas-dev/pandas-stubs/tree/v1.5.3.230203
license: https://github.com/pandas-dev/pandas-stubs/blob/v1.5.3.230203/LICENSE
pyproject.toml: https://github.com/pandas-dev/pandas-stubs/blob/v1.5.3.230203/pyproject.toml

## Changes 
- Bump version and SHA
- Add `--no-deps` to `pip install`
- Change to valid URL

## Notes
- This release adds python 3.11 support
- The standard short PyPi URL is unavailable, GitHub archive URL was used instead
- Since this just adds shims, I did not find a good include test. And the unit tests in the upstream requires an enormous amount of dependencies (some of which are not present). I'm open to suggestions for additional tests.
- s390x is skipped due to missing `types-pytz>=2022.1.1`
