### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pandas-stubs" %}
-{% set version = "2.1.4.231227" %}
+{% set version = "2.2.2.240909" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pandas_stubs-{{ version }}.tar.gz
-  sha256: 3ea29ef001e9e44985f5ebde02d4413f94891ef6ec7e5056fb07d125be796c23
+  sha256: 3c0951a2c3e45e3475aed9d80b7147ae82f176b9e42e9fb321cfdebf3d411b3d
 
 build:
   number: 0


### PR DESCRIPTION
If possible, it would be best if whenever `conda-forge` is updated for `pandas-stubs`, then this gets updated as well, since the package is just a set of stub files, it shouldn't introduce any other incompatibilities for people.

{package} {version} {:snowflake:}

**Destination channel:** {Snowflake | defaults}

### Links

- [{ticket_number}]() 
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- ...
