### PR TITLE
pandas-stubs 2.3.2.250926 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "pandas-stubs" %}
-{% set version = "2.2.3.250308" %}
+{% set version = "2.3.2.250926" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pandas_stubs-{{ version }}.tar.gz
-  sha256: 3a6e9daf161f00b85c83772ed3d5cff9522028f07a94817472c07b91f46710fd
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_")}}-{{ version }}.tar.gz
+  sha256: c64b9932760ceefb96a3222b953e6a251321a9832a28548be6506df473a66406
 
 build:
   number: 0
-  # s390x is missing types-pytz
-  skip: True  # [py<310 or s390x]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<310 or py>313]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
@@ -30,6 +29,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - test -f $SP_DIR/pandas-stubs/_typing.pyi  # [unix]
     - if not exist %SP_DIR%\\pandas-stubs\\_typing.pyi exit 1  # [win]
 


### PR DESCRIPTION
pandas-stubs 2.3.2.250926 

**Destination channel:** Defaults

### Links

- [PKG-10457]
- dev_url:        https://github.com/pandas-dev/pandas-stubs/tree/v2.3.2.250926
- conda_forge:    https://github.com/conda-forge/pandas-stubs-feedstock
- pypi:           https://pypi.org/project/pandas-stubs/2.3.2.250926
- pypi inspector: https://inspector.pypi.io/project/pandas-stubs/2.3.2.250926

### Explanation of changes:

- Bumped version: 2.2.3.250308 → 2.3.2.250926
- Added test to assert package version via importlib.metadata
- Minor cleanups for consistency (URL format, verbosity)


[PKG-10457]: https://anaconda.atlassian.net/browse/PKG-10457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ